### PR TITLE
DS 6.1; Fixes for Optional steps docs and build

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ The current version is 22.03 and the base docker used in the above Dockerfile is
 Note: For customers to be able to upgrade to any of the new Triton versions,
 they need to confirm API & ABI compatibility with the respective Triton version.
 
-### 1.1.1 Prerequisites; (DeepStreamSDK package and terminology)
+### 1.1.1 Prerequisites; Mandatory; (DeepStreamSDK package and terminology)
 
-1) Please download the [DeepStreamSDK release](https://developer.nvidia.com/deepstream-getting-started) tarball and place it locally
+1) Please download the [DeepStreamSDK release](https://developer.nvidia.com/deepstream-getting-started) x86 tarball and place it locally
 in the ``$ROOT/x86_64`` folder of this repository.
 
 2) `image_url` is the desired docker name:TAG
@@ -43,23 +43,24 @@ tarball extension respectively. Refer to [Section 1.1.3 Build Command](#113-buil
 provided in the command above. This name is used in the triton build steps alone.
 Refer to [Section 1.1.3 Build Command](#113-build-command) for sample command.
 
-### 1.1.2 Prerequisites; (TensorRT and other third-party packages)
+### 1.1.2 Prerequisites; Optional; (TensorRT and other third-party packages)
 
-1) Adding uff-converter-tf and graphsurgeon-tf packages.  
-Download file link: [nv-tensorrt-repo-ubuntu1804-cuda11.3-trt8.0.1.6-ga-20210626_1-1_amd64.deb](https://developer.nvidia.com/compute/machine-learning/tensorrt/secure/8.0.1/local_repos/nv-tensorrt-repo-ubuntu1804-cuda11.3-trt8.0.1.6-ga-20210626_1-1_amd64.deb) from TensorRT download page.  
+1) Adding uff-converter-tf and graphsurgeon-tf packages.
+
+Note: This is an optional step to install uff-converter-tf and graphsurgeon-tf packages.
+
+Download file link: [nv-tensorrt-repo-ubuntu2004-cuda11.4-trt8.2.5.1-ga-20220505_1-1_amd64.deb](https://developer.nvidia.com/compute/machine-learning/tensorrt/secure/8.2.5.1/local_repos/nv-tensorrt-repo-ubuntu2004-cuda11.4-trt8.2.5.1-ga-20220505_1-1_amd64.deb) from TensorRT download page.  
 Note: You may have to login to [developer.nvidia.com](https://developer.nvidia.com/) to download the file.  
 Quick Steps:  
 $ROOT is the root directory of this git repo.    
 ``cd $ROOT``  
 ``mkdir tmp``  
-``dpkg-deb -R nv-tensorrt-repo-ubuntu1804-cuda11.3-trt8.0.1.6-ga-20210626_1-1_amd64.deb tmp``  
-``cp tmp/var/nv-tensorrt-repo-ubuntu1804-cuda11.3-trt8.0.1.6-ga-20210626/uff-converter-tf_8.0.1-1+cuda11.3_amd64.deb x86_64/``  
-``cp tmp/var/nv-tensorrt-repo-ubuntu1804-cuda11.3-trt8.0.1.6-ga-20210626/graphsurgeon-tf_8.0.1-1+cuda11.3_amd64.deb x86_64/``  
+``dpkg-deb -R nv-tensorrt-repo-ubuntu2004-cuda11.4-trt8.2.5.1-ga-20220505_1-1_amd64.deb tmp``  
+``cp tmp/var/nv-tensorrt-repo-ubuntu2004-cuda11.4-trt8.2.5.1-ga-20220505/uff-converter-tf_8.2.5-1+cuda11.4_amd64.deb x86_64/``  
+``cp tmp/var/nv-tensorrt-repo-ubuntu2004-cuda11.4-trt8.2.5.1-ga-20220505/graphsurgeon-tf_8.2.5-1+cuda11.4_amd64.deb x86_64/``  
 
-2) Installing TRT Python3 API.  
-Download into ``x86_64/deps/misc`` folder the TensorRT- tarball installation file - "TensorRT 8.0.1 GA for Linux x86_64 and CUDA 11.3 TAR package" from:
-https://developer.nvidia.com/nvidia-tensorrt-download  
-Download file link:  [TensorRT-8.0.1.6.Linux.x86_64-gnu.cuda-11.3.cudnn8.2.tar.gz](https://developer.nvidia.com/compute/machine-learning/tensorrt/secure/8.0.1/tars/tensorrt-8.0.1.6.linux.x86_64-gnu.cuda-11.3.cudnn8.2.tar.gz)  
+Note: Please uncomment corresponding installation commands in ``x86_64/trtserver_base_devel/Dockerfile`` to install these optional packages inside the container.
+
 ### 1.1.3 Build Command
 
 ```

--- a/x86_64/trtserver_base_devel/Dockerfile
+++ b/x86_64/trtserver_base_devel/Dockerfile
@@ -143,24 +143,7 @@ RUN echo "Please follow README for Required Extra Step (1) if the following inst
 #	rm /root/uff-converter-tf_${TENSORRT_VERSION}_amd64.deb  \
 #	/root/graphsurgeon-tf_${TENSORRT_VERSION}_amd64.deb
 
-# @} Adding uff-converter-tf
-
-# @{ Extra Step (2): Installing TRT Python3 API
-
-#Note: Download into x86_64/deps/misc folder the TensorRT- tarball installation file from:
-# https://developer.nvidia.com/nvidia-tensorrt-download
-
-RUN echo "Please follow README for Required Extra Step (2) if the following installation fail for missing files"
-
-#Uncomment the following lines of code for ADD and RUN
-
-#ADD deps/misc/TensorRT-8.0.1.6.Linux.x86_64-gnu.cuda-11.3.cudnn8.2.tar.gz /root/
-#RUN pip3 install /root/TensorRT-8.0.1.6/python/tensorrt-8.0.1.6-cp38-none-linux_x86_64.whl
-#RUN rm -rf /root/TensorRT-8.0.1*
-
-# @} Installing TRT Python API
-
-
+# @} Adding uff-converter-tf and graphsurgeon-tf packages
 
 COPY trtserver_base_runtime/10_nvidia.json /usr/share/glvnd/egl_vendor.d/10_nvidia.json
 COPY trtserver_base_runtime/entrypoint.sh ${DS_DIR}/


### PR DESCRIPTION
1) Removing x86 docker build Section 1.1.2 - Extra step (2)
as python3 API's are now installed with apt-get automatically
python3-libnvinfer and python3-libnvinfer-dev packages

2) Fixed TRT debian download links to use TRT 8.2.5.1 in
README.md/Section 1.1.2

Tests:

Verified docker build after uncommenting optional package installation code
in Dockerfile
following Section 1.1.2 for x86 build