### PR TITLE
Triton Migration Guide update for DS 6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
-# DeepStream 6.1.1 Triton Migration Guide
+# DeepStream 6.2 Triton Migration Guide
 
 The documentation here is intended to help customers upgrade the Triton
 version from the version DeepStreamSDK was tested and released with.
 This information is useful for upgrading Triton on both x86 systems with dGPU setup
 and on NVIDIA Jetson devices.
 
-Example: User may follow the instructions here to upgrade deployment of DeepStreamSDK 6.1.1 which
-support Triton 22.07 (on dGPU and Jetson) to a more recent Triton version like 22.08.
+Example: User may follow the instructions here to upgrade deployment of DeepStreamSDK 6.2 which
+support Triton 22.09 (on dGPU) and 23.01 (on Jetson) to a more recent Triton version like 23.01 (on dGPU).
+
+Note: Jetson Triton Migration to 23.02 will be demonstrated here once the 23.02 release is available.
+Currently, DS 6.2 already use the latest Triton version, 23.01.
 
 This repo have artefacts that can be used to generate NVIDIA DeepStream Triton Docker for x86 machines.
 For Jetson, please refer to [section 1.2 Jetson Binaries Update](#12-jetson-binaries-update).
 
 ### Additional Installations to use all DeepStreamSDK Features.
 
-With DS 6.1.1, DeepStream docker containers do not package libraries necessary for certain multimedia operations like audio data parsing, CPU decode, and CPU encode.
+With DS 6.2, DeepStream docker containers do not package libraries necessary for certain multimedia operations like audio data parsing, CPU decode, and CPU encode.
 This change could affect processing certain video streams/files like mp4 that include audio tracks.
 
 Please run the below script inside the docker images to install additional packages that might be necessary to use all of the DeepStreamSDK features :
@@ -32,8 +35,11 @@ Thus, if a customer wants to change the Triton version, they may do so by
 updating the version number on the base docker at:
 ``x86_64/trtserver_base_devel/Dockerfile``
 
-The current version is 22.07 and the base docker used in the above Dockerfile is:
-``nvcr.io/nvidia/tritonserver:22.07-py3``
+The current version used by DS 6.2 official release is 22.09:
+``nvcr.io/nvidia/tritonserver:22.09-py3``
+
+The base docker used in the above Dockerfile is to demonstrate migration to Triton 23.01:
+``nvcr.io/nvidia/tritonserver:23.01-py3``
 
 Note: For customers to be able to upgrade to any of the new Triton versions,
 they need to confirm API & ABI compatibility with the respective Triton version.
@@ -46,166 +52,46 @@ in the ``$ROOT/x86_64`` folder of this repository.
 2) `image_url` is the desired docker name:TAG
 
 3) `ds_pkg` and `ds_pkg_dir` shall be the tarball file-name with and without the
-tarball extension respectively. Refer to [Section 1.1.3 Build Command](#113-build-command) for sample command.
+tarball extension respectively.
+`ds_pkg` is also the DS tarball file-path relative to `$ROOT/x86_64`
+Refer to [Section 1.1.3 Build Command](#113-build-command) for sample command.
 
 4) `base_image` is the desired container name. Please feel free to use the sample name
 provided in the command above. This name is used in the triton build steps alone.
 Refer to [Section 1.1.3 Build Command](#113-build-command) for sample command.
 
-### 1.1.2 Prerequisites; Optional; (TensorRT and other third-party packages)
+### 1.1.2 Installing Specific TensorRT Version
 
-1) Adding uff-converter-tf and graphsurgeon-tf packages.
+DeepStreamSDK 6.2 supports TensorRT 8.5.2 (TensorRT 8.5 GA Update 1).
 
-Note: This is an optional step to install uff-converter-tf and graphsurgeon-tf packages.
+Users can install specific TensorRT version - say TensorRT 8.5.2 by following instructions
+at line 33 and uncommenting lines 38-68 on the file: `x86_64/trtserver_base_devel/Dockerfile`.
 
-Download file link: [nv-tensorrt-repo-ubuntu2004-cuda11.6-trt8.4.1.5-ga-20220604_1-1_amd64.deb](https://developer.nvidia.com/compute/machine-learning/tensorrt/secure/8.4.1/local_repos/nv-tensorrt-repo-ubuntu2004-cuda11.6-trt8.4.1.5-ga-20220604_1-1_amd64.deb) from TensorRT download page.
-Note: You may have to login to [developer.nvidia.com](https://developer.nvidia.com/) to download the file.  
-Quick Steps:  
-$ROOT is the root directory of this git repo.    
-``cd $ROOT``  
-``mkdir tmp``  
-``dpkg-deb -R nv-tensorrt-repo-ubuntu2004-cuda11.6-trt8.4.1.5-ga-20220604_1-1_amd64.deb tmp``  
-``cp tmp/var/nv-tensorrt-repo-ubuntu2004-cuda11.6-trt8.4.1.5-ga-20220604/uff-converter-tf_8.4.1-1+cuda11.6_amd64.deb x86_64/``  
-``cp tmp/var/nv-tensorrt-repo-ubuntu2004-cuda11.6-trt8.4.1.5-ga-20220604/graphsurgeon-tf_8.4.1-1+cuda11.6_amd64.deb x86_64/``  
+TensorRT debian should already be downloaded into `x86_64` directory from https://developer.nvidia.com/nvidia-tensorrt-8x-download
+``nv-tensorrt-local-repo-ubuntu2004-8.5.2-cuda-11.8_1.0-1_amd64.deb``.
 
-Note: Please uncomment corresponding installation commands in ``x86_64/trtserver_base_devel/Dockerfile`` to install these optional packages inside the container.
+Note: Users will need to change the TensorRT version macro `${TENSORRT_VERSION}`, `${CUDNN_VERSION_2}` at `x86_64/Makefile` if installing any other version than TensorRT 8.5.2.
+To obtain this version string, please first install TensorRT manually following [installation guide](https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-852/install-guide/index.html) and check:
+
+``dpkg -l | grep tensorrt``
+
+``dpkg -l | grep cudnn``
+
 
 ### 1.1.3 Build Command
 
 ```
-sudo image_url=deepstream:6.1.1-triton-local \
-     ds_pkg=deepstream_sdk_v6.1.1_x86_64.tbz2 \
-     ds_pkg_dir=deepstream_sdk_v6.1.1.0_x86_64/ \
+sudo image_url=deepstream:6.2-triton-local \
+     ds_pkg=deepstream_sdk_v6.2.0_x86_64.tbz2 \
+     ds_pkg_dir=deepstream_sdk_v6.2.0_x86_64/ \
      base_image=dgpu-any-custom-base-image make triton-devel -C x86_64/
 ```
 
 ## 1.2 Jetson binaries update
 
-Note: [Triton Inference Server 22.08](https://github.com/triton-inference-server/server/releases/tag/v2.25.0) does not support Jetpack.
-Users will have to use [22.07](https://github.com/triton-inference-server/server/releases/download/v2.24.0) - already the latest in DS 6.1.1 triton docker image.
+Note: Jetson Triton Migration to 23.02 will be demonstrated here once the 23.02 release is available.
+Currently, DS 6.2 already use the latest Triton version, 23.01.
 
-Triton Inference Server release packages could be found at https://github.com/triton-inference-server/server/releases.
-
-To upgrade the triton version on Jetson DeepStream setup, we shall replace certain libraries as discussed in the Sections below.
-
-#### Create new Jetson triton container image with new Triton version
-
-
-1) Open the file ``jetson/deps/misc/triton_backend_setup.sh`` and replace the
-link to jetpack tarball for the variable ``TRITON_PKG_PATH``.  
-Procure the link to this file from Triton Release page at https://github.com/triton-inference-server/server/releases  
-Example, to upgrade to Triton 22.07, replace the variable value with:  
- ``TRITON_PKG_PATH=https://github.com/triton-inference-server/server/releases/download/v2.24.0/tritonserver2.24.0-jetpack5.0.2.tgz``
-
-Note: [Triton Inference Server 22.08](https://github.com/triton-inference-server/server/releases/tag/v2.25.0) does not support Jetpack.
-Users will have to use [22.07](https://github.com/triton-inference-server/server/releases/download/v2.24.0) - already the latest in DS 6.1.1 triton docker image.
-
-2) [Optional] Open file ``jetson/Dockerfile`` and use the ds6.1.1-samples container image as base
-instead of ds6.1.1-triton. ds6.1.1-triton has additional development libraries and headers
-to build DeepStream reference application and these may not be required for deployment.
-By default, the ds6.1.1-triton container image will be used as base to create the new image.
-
-3) Now run the following command:
-
-```
-sudo docker build jetson/ -t deepstream-l4t:6.1.1-triton-custom
-```
-
-#### Easy way to do Steps 1.2.1 and 1.2.2
-
-1) Please Install DeepStream 6.1.1 Package on the Jetson machine.
-
-2) Open the file: ``/opt/nvidia/deepstream/deepstream/samples/triton_backend_setup.sh``
-
-3) Replace the link to jetpack tarball for the variable ``TRITON_PKG_PATH``.  
-Procure the link to this file from Triton Release page at https://github.com/triton-inference-server/server/releases  
-Example, to upgrade to Triton 22.07, replace the variable value with:  
- ``TRITON_PKG_PATH=https://github.com/triton-inference-server/server/releases/download/v2.24.0/tritonserver2.24.0-jetpack5.0.2.tgz``
-
-Note: [Triton Inference Server 22.08](https://github.com/triton-inference-server/server/releases/tag/v2.25.0) does not support Jetpack.
-Users will have to use [22.07](https://github.com/triton-inference-server/server/releases/download/v2.24.0) - already the latest in DS 6.1.1 triton docker image.
-
-4) Now run the shell script:
-
-a) ``cd /opt/nvidia/deepstream/deepstream/samples/``
-
-b) ``./triton_backend_setup.sh``
-
-### 1.2.1 Replace the backend libs for TF1 and TF2.
-
-DS-Triton default backend location for Jetson: ``/opt/nvidia/deepstream/deepstream/lib/triton_backends``
-
-When users upgrade triton, they need to copy/replace their backends(TF/Custom) into the above folder.
-
-Take Triton 22.07 for example; backends could be found from https://github.com/triton-inference-server/server/releases/tag/v2.21.0.
-
-Jetson backends and libs are in [tritonserver2.24.0-jetpack5.0.2.tgz](https://github.com/triton-inference-server/server/releases/download/v2.24.0/tritonserver2.24.0-jetpack5.0.2.tgz).
-Currently, there are TF1/TF2 backends supported on Jetson.
-Users can try other triton versions and backends from release packages if the new interface is API & ABI compatible with Triton 22.07.
-Tensorflow backends source code are available at https://github.com/triton-inference-server/tensorflow_backend/tree/r22.07
-
-
-For TensorFlow-1 backends, Users should replace folder ``/opt/nvidia/deepstream/deepstream/lib/triton_backends/tensorflow1`` with specific build TensorFlow-1 backend libs. The folder tree as below
-
-```
-/opt/nvidia/deepstream/deepstream/lib/triton_backends/tensorflow1
-
-├── libtensorflow_cc.so -> libtensorflow_cc.so.1
-
-├── libtensorflow_cc.so.1 -> libtensorflow_triton.so.1
-
-├── libtensorflow_framework.so -> libtensorflow_framework.so.1
-
-├── libtensorflow_framework.so.1 -> libtensorflow_triton.so.1
-
-├── libtensorflow_triton.so -> libtensorflow_triton.so.1
-
-├── libtensorflow_triton.so.1
-
-└── libtriton_tensorflow1.so
-```
-
-
-For TensorFlow-2 backends, users shall replace folder ``/opt/nvidia/deepstream/deepstream/lib/triton_backends/tensorflow2`` with specific build TensorFlow-2 backend libs. Folder tree as below
-
-```
-/opt/nvidia/deepstream/deepstream/lib/triton_backends/tensorflow2
-
-├── libtensorflow_cc.so -> libtensorflow_cc.so.2
-
-├── libtensorflow_cc.so.2 -> libtensorflow_triton.so.2
-
-├── libtensorflow_framework.so -> libtensorflow_framework.so.2
-
-├── libtensorflow_framework.so.2 -> libtensorflow_triton.so.2
-
-├── libtensorflow_triton.so -> libtensorflow_triton.so.2
-
-├── libtensorflow_triton.so.2
-
-└── libtriton_tensorflow2.so
-```
-
-Instead of replacing the default backends location, another option is that, update gst-nvinferserver config file to user’s new backends folder.
-
-```
-       trtis { model_repo {
-
-          backend_dir: /path/to/new/backends/
-
-        }}
-```
-
-### 1.2.2 Replace the server lib
-
-Users need to replace ``/opt/nvidia/deepstream/deepstream/lib/libtritonserver.so`` with a specific triton build version.
-From [Triton release webpage](https://github.com/triton-inference-server/server/releases), users could find "Jetson Jetpack Support" section to download specific tritonserver libs.
-
-For example, TritonServer 22.07 lib is in [tritonserver2.24.0-jetpack5.0.2.tgz](https://github.com/triton-inference-server/server/releases/download/v2.24.0/tritonserver2.24.0-jetpack5.0.2.tgz).
-And source code is from https://github.com/triton-inference-server/server/tree/r22.07.
-
-Note: [Triton Inference Server 22.08](https://github.com/triton-inference-server/server/releases/tag/v2.25.0) does not support Jetpack.
-Users will have to use [22.07](https://github.com/triton-inference-server/server/releases/download/v2.24.0) - already the latest in DS 6.1.1 triton docker image.
 
 ### 1.3 Triton Backend upgrade
 
@@ -233,18 +119,20 @@ Users can also update gst-nvinferserver’s config file to the new backends fold
 
 ### 2.1 Tritonserver lib upgrade
 
-DeepStream 6.1.1 Triton Server API is based on Triton 22.07 (x86 and Jetson) release.
+DeepStream 6.2 Triton Server API is based on Triton 22.09 (x86) and Triton 23.01 (Jetson) release.
 
 Regarding API compatibility, if a customer wants to upgrade triton, they need to make sure:
 
 a) new version's `tritonserver.h` is compatible with  the:
 
-[22.07 version of tritonserver.h for x86 and jetson](https://github.com/triton-inference-server/core/blob/r22.07/include/triton/core/tritonserver.h), 
+[22.09 version of tritonserver.h for x86](https://github.com/triton-inference-server/core/blob/r22.09/include/triton/core/tritonserver.h), 
+[23.01 version of tritonserver.h for jetson](https://github.com/triton-inference-server/core/blob/r23.01/include/triton/core/tritonserver.h), 
 and 
 
 b) new version’s `model_config.proto` is compatible with:
 
-[22.07 version for x86 and jetson](https://github.com/triton-inference-server/server/blob/r22.07/src/core/model_config.proto), 
+[22.09 version for x86 and jetson](https://github.com/triton-inference-server/server/blob/r22.09/src/core/model_config.proto), 
+[23.01 version for jetson](https://github.com/triton-inference-server/server/blob/r23.01/src/core/model_config.proto), 
 
 To build specific Tritonserver version libs, users can follow instructions at https://github.com/triton-inference-server/server/blob/master/docs/build.md.
 
@@ -252,13 +140,13 @@ To build specific Tritonserver version libs, users can follow instructions at ht
 ### 2.2 DeepStream Config file Requirement
 
 Gst-nvinferserver plugin’s config file kept backward compatibility.
-Triton model/backend’s config.pbtxt file must follow rules of 22.07’s ``model_config.proto`` for x86 and 
-22.07's ``model_config.proto`` for jetson.
+Triton model/backend’s config.pbtxt file must follow rules of 22.09’s ``model_config.proto`` for x86 and 
+23.01's ``model_config.proto`` for jetson.
 
 ## 3 Ubuntu Version Requirements
 
 ### 3.1 Ubuntu 20.04 (Triton 21.02+)
 
-DeepStream 6.1.1 release package inherently support Ubuntu 20.04.
+DeepStream 6.2 release package inherently support Ubuntu 20.04.
 
 Thus, the only thing to consider is API/ABI compatibility between the new Triton version and the Triton version supported by current DS release.

--- a/common/install_triton-devel.sh
+++ b/common/install_triton-devel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-23 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -74,3 +74,4 @@ utils_install_libhiredis_from_source
 cp /root/tmp/LicenseAgreementContainer.pdf /opt/nvidia/deepstream/deepstream/
 
 mv /opt/user_additional_install_devel.sh /opt/nvidia/deepstream/deepstream/user_additional_install.sh
+mv /opt/user_deepstream_python_apps_install.sh /opt/nvidia/deepstream/deepstream/user_deepstream_python_apps_install.sh

--- a/common/version
+++ b/common/version
@@ -1,4 +1,4 @@
-version=6.1.1
+version=6.2.0
 tag=gmc1
 registry ?= nvcr.io/nvidian
 image_tag=$(version)-$(tag)

--- a/jetson/Dockerfile
+++ b/jetson/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-23 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -24,9 +24,9 @@
 # Uncomment line #28 and comment out the line #30
 # to use samples as base docker for a lighter container image.
 
-# FROM nvcr.io/nvidia/deepstream-l4t:6.1.1-samples
+# FROM nvcr.io/nvidia/deepstream-l4t:6.2-samples
 
-FROM nvcr.io/nvidia/deepstream-l4t:6.1.1-triton
+FROM nvcr.io/nvidia/deepstream-l4t:6.2-triton
 
 # ADD the triton backend installation script and execute the same
 # Note: Users need to update the URL to procure newer Triton release

--- a/x86_64/Makefile
+++ b/x86_64/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-23 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -21,10 +21,10 @@
 img_type = triton-devel
 prefix = deepstream_x86
 platform = x86_64
-ds_dir = /opt/nvidia/deepstream/deepstream-6.1
-platform_build_arg = --build-arg TENSORRT_VERSION="8.4.1-1+cuda11.6"
-platform_build_arg += --build-arg CUDNN_VERSION_2="8.4.1.67-1+cuda11.6"
-platform_build_arg += --build-arg CUDA_VERSION="11.7.1"
+ds_dir = /opt/nvidia/deepstream/deepstream-6.2
+platform_build_arg = --build-arg TENSORRT_VERSION="8.5.2-1+cuda11.8"
+platform_build_arg += --build-arg CUDNN_VERSION_2="8.7.0.84-1+cuda11.8"
+platform_build_arg += --build-arg CUDA_VERSION="11.8.0"
 platform_build_arg += --build-arg DS_DIR=$(ds_dir)
 
 DOCKER=docker

--- a/x86_64/deps/ofed-ucx.conf
+++ b/x86_64/deps/ofed-ucx.conf
@@ -1,0 +1,6 @@
+rdma-core=y
+libibverbs1=y
+libibverbs-dev=y
+ibverbs-providers=y
+librdmacm1=y
+librdmacm-dev=y

--- a/x86_64/deps/user_additional_install_devel.sh
+++ b/x86_64/deps/user_additional_install_devel.sh
@@ -1,4 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-23 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -18,3 +20,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+# additional components the user can self install
+apt-get update
+apt-get install -y gstreamer1.0-libav
+apt-get install --reinstall -y gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly libavresample-dev libavresample4 libavutil-dev libavutil56 libavcodec-dev libavcodec58 libavformat-dev libavformat58 libavfilter7 libde265-dev libde265-0 libx264-155 libx265-179 libvpx6 libmpeg2encpp-2.1-0 libmpeg2-4 libmpg123-0
+

--- a/x86_64/deps/user_deepstream_python_apps_install.sh
+++ b/x86_64/deps/user_deepstream_python_apps_install.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+# additional components the user can self install
+
+# User script to download and install PyDS from https://github.com/NVIDIA-AI-IOT/deepstream_python_apps
+# -v option can be used to specify which version of PyDS to download and install
+# -b option can be used to indicate that latest available bindings should be downloaded and installed
+
+function usage() {
+  echo "Usage: $0 -v PyDS-version -b (build-latest-bindings)"
+  echo "  -v, --version            The version of PyDS to download and install"
+  echo "  OR  "
+  echo "  -b, --build-bindings     Compile and install latest PyDS instead of downloading wheels"
+  echo "  -r, --remote-branch      Specify which branch of deepstream_python_apps to clone and build from"
+  echo ""
+  echo "Example: $0 --version 1.1.4"
+  echo "Example: $0 --build-bindings"
+  echo "Example: $0 --build-bindings -r master"
+  exit 1
+}
+
+while [[ "$#" > 0 ]]; do
+    case $1 in
+        -v|--version) version="$2"; shift 2;;
+        -r|--remote-branch) remote_branch="$2"; shift 2;;
+        -b|--build-bindings) build_bindings=1; shift 1;;
+        -h|--help) usage; shift 1;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+done
+
+if [ -z "$version" ] && [ -z "$build_bindings" ]; then usage "The version of PyDS to download and install"; fi;
+
+cd /opt/nvidia/deepstream/deepstream
+echo "####################################"
+echo "Downloading necessary pre-requisites"
+echo "####################################"
+apt-get update
+apt-get install -y gstreamer1.0-libav
+apt-get install --reinstall -y gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly libavresample-dev libavresample4 libavutil-dev libavutil56 libavcodec-dev libavcodec58 libavformat-dev libavformat58 libavfilter7 libde265-dev libde265-0 libx264-155 libx265-179 libvpx6 libmpeg2encpp-2.1-0 libmpeg2-4 libmpg123-0
+apt install -y python3-gi python3-dev python3-gst-1.0 python-gi-dev git python-dev python3 python3-pip python3.8-dev cmake g++ build-essential libglib2.0-dev libglib2.0-dev-bin libgstreamer1.0-dev libtool m4 autoconf automake libgirepository1.0-dev libcairo2-dev
+cd /opt/nvidia/deepstream/deepstream/sources
+if [ -z "$remote_branch" ]
+then
+    remote_branch="master"
+    echo "#################################"
+    echo "Default sync branch set to master"
+    echo "#################################"
+fi
+
+git clone -b "$remote_branch" https://github.com/NVIDIA-AI-IOT/deepstream_python_apps.git
+if [ $? -eq 0 ]; then
+   echo "deepstream_python_apps cloned successfully from branch $remote_branch"
+else
+   echo "deepstream_python_apps clone from branch $remote_branch FAILED! Exiting..."
+   exit 1
+fi
+
+if [ -z "$version" ] && [ $build_bindings == 1 ]
+then
+    echo "############################"
+    echo "Building downloaded bindings"
+    echo "############################"
+    cd /opt/nvidia/deepstream/deepstream/sources/deepstream_python_apps
+    git submodule update --init
+    apt-get install -y apt-transport-https ca-certificates -y
+    update-ca-certificates
+    cd 3rdparty/gst-python/
+    ./autogen.sh
+    make
+    make install
+    cd /opt/nvidia/deepstream/deepstream/sources/deepstream_python_apps/bindings
+    rm -rf build && mkdir build && cd build
+    cmake ..
+    make
+    echo "###########################"
+    echo "Installing built PyDS wheel"
+    echo "###########################"
+    pip3 install ./pyds-1*_x86_64.whl
+elif [ -z "$build_bindings" ] && [[ ! -z $version ]]
+then
+    echo "##############################"
+    echo "Pulling PyDS version: $version"
+    echo "##############################"
+    cd /opt/nvidia/deepstream/deepstream/sources/deepstream_python_apps
+    URL="https://github.com/NVIDIA-AI-IOT/deepstream_python_apps/releases/download/v$version/pyds-$version-py3-none-linux_x86_64.whl"
+    echo "url"
+    echo $URL
+    wget "$URL"
+    if [ -f "pyds-$version-py3-none-linux_x86_64.whl" ]
+    then
+        echo "########################################################"
+        echo "Downloaded wheel pyds-$version-py3-none-linux_x86_64.whl"
+        echo "########################################################"
+    else
+        echo "#########################################"
+        echo "PyDS wheel was not downloaded. Exiting..."
+        echo "#########################################"
+        exit 1
+    fi
+    echo "#####################"
+    echo "Installing PyDS wheel"
+    echo "#####################"
+    pip3 install pyds-$version-py3-none-linux_x86_64.whl
+fi

--- a/x86_64/triton_user_additional_install_devel.sh
+++ b/x86_64/triton_user_additional_install_devel.sh
@@ -1,4 +1,0 @@
-# additional components the user can self install
-apt-get update
-apt-get install -y gstreamer1.0-libav
-apt-get install --reinstall -y gstreamer1.0-plugins-good gstreamer1.0-plugins-bad libavresample-dev libavresample4 libavutil-dev libavutil56 libavcodec-dev libavcodec58 libavformat-dev libavformat58 libavfilter7

--- a/x86_64/trtserver_base_devel/Dockerfile
+++ b/x86_64/trtserver_base_devel/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-23 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -19,7 +19,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-FROM nvcr.io/nvidia/tritonserver:22.07-py3
+FROM nvcr.io/nvidia/tritonserver:23.01-py3
 
 ARG TENSORRT_VERSION
 ARG CUDNN_VERSION_2
@@ -32,20 +32,40 @@ RUN head -n -2 /etc/apt/sources.list > /tmp/tmp.txt && mv /tmp/tmp.txt /etc/apt/
 
 #Installing specific TRT, CuDNN versions over the versions provided by the Triton base docker image
 #Users may uncomment below if needed and declare the compute lib versions at x86_64/Makefile
+
+# NOTE: The following debian should already be downloaded into x86_64 directory
+# from https://developer.nvidia.com/nvidia-tensorrt-8x-download
+# ADD nv-tensorrt-local-repo-ubuntu2004-8.5.2-cuda-11.8_1.0-1_amd64.deb /tmp
+#RUN mkdir -p /tmp/temp_trt && \
+#        cd /tmp/temp_trt && \
+#        cp /tmp/nv-tensorrt-local-repo-ubuntu2004-8.5.2-cuda-11.8_1.0-1_amd64.deb  /tmp/temp_trt && \
+#        ls -l /tmp/temp_trt/ && \
+#        dpkg -i /tmp/temp_trt/nv-tensorrt-local-repo-ubuntu2004-8.5.2-cuda-11.8_1.0-1_amd64.deb && \
+#        cp /var/nv-tensorrt-local-repo-ubuntu2004-8.5.2-cuda-11.8/nv-tensorrt-local-9A139056-keyring.gpg /usr/share/keyrings/ && \
+#        apt-get update && \
+#        DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+#        libnvinfer8=${TENSORRT_VERSION} \
+#        libnvinfer-plugin8=${TENSORRT_VERSION} \
+#        libnvparsers8=${TENSORRT_VERSION} \
+#        libnvonnxparsers8=${TENSORRT_VERSION} \
+#        libnvinfer-bin=${TENSORRT_VERSION} \
+#        libnvinfer-dev=${TENSORRT_VERSION} \
+#        libnvinfer-plugin-dev=${TENSORRT_VERSION} \
+#        libnvparsers-dev=${TENSORRT_VERSION} \
+#        libnvonnxparsers-dev=${TENSORRT_VERSION} \
+#        libnvinfer-samples=${TENSORRT_VERSION} \
+#        python3-libnvinfer=${TENSORRT_VERSION} \
+#        python3-libnvinfer-dev=${TENSORRT_VERSION} \
+#        uff-converter-tf=${TENSORRT_VERSION} \
+#        graphsurgeon-tf=${TENSORRT_VERSION} \
+#        libcudnn8-dev && \
+#        cd /tmp && \
+#        rm -rf temp_trt && \
+#        rm -rf /var/lib/apt/lists/*
 #RUN apt-get update && \
 #        DEBIAN_FRONTEND=noninteractive  apt-get install -y --no-install-recommends \
 #        libcudnn8=${CUDNN_VERSION_2} \
 #        libcudnn8-dev=${CUDNN_VERSION_2} \
-#        libnvinfer8=${TENSORRT_VERSION} \
-#        libnvinfer-dev=${TENSORRT_VERSION} \
-#        libnvparsers8=${TENSORRT_VERSION} \
-#        libnvparsers-dev=${TENSORRT_VERSION} \
-#        libnvonnxparsers8=${TENSORRT_VERSION} \
-#        libnvonnxparsers-dev=${TENSORRT_VERSION} \
-#        libnvinfer-plugin8=${TENSORRT_VERSION} \
-#        libnvinfer-plugin-dev=${TENSORRT_VERSION} \
-#        python3-libnvinfer=${TENSORRT_VERSION} \
-#        python3-libnvinfer-dev=${TENSORRT_VERSION}
 
 # install realsense sdk for 3d camera (Optional; disabled by default)
 # instructions: https://github.com/IntelRealSense/librealsense/blob/master/doc/distribution_linux.md
@@ -119,32 +139,73 @@ RUN apt-get update && \
         git \
         gnutls-bin \
         rsyslog \
+        libjsoncpp-dev \
+        python3-pip \
+        libksba8 \
         vim  \
         wget \
+        unzip \
         python-is-python3 \
         && rm -rf /var/lib/apt/lists/* \
         ; apt autoremove
 
-# @{ Extra Step (1) Adding uff-converter-tf and graphsurgeon-tf packages
+# To migrate to Triton 23.01 or later, users will have to install CUDA 11.8 alongside
+# CUDA 12.0 which comes from Triton 23.01 base image
+RUN echo "Please comment the following RUN command installing CUDA 11.8 if you're migrating to Triton 22.10, 22.11, or 22.12"
+RUN wget https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run --no-check-certificate --no-verbose && \
+    chmod +x cuda_11.8.0_520.61.05_linux.run && \
+    ./cuda_11.8.0_520.61.05_linux.run --help && \
+    ./cuda_11.8.0_520.61.05_linux.run --silent --toolkit && rm cuda_11.8.0_520.61.05_linux.run
 
-#Note: Download into x86_64/ folder
-# the said packages from the TensorRT repo link for the TRT and Ubuntu version you want to use
-#Example: http://cuda-repo/release-candidates/Libraries/TensorRT/v8.0/8.0.1.6-d2333911/11.3-r465/Ubuntu18_04-x64/deb/
+# @{ Extra Steps to install dependencies for DeepStreamSDK UCX plugins
 
-RUN echo "Please follow README for Required Extra Step (1) if the following installation fail for missing files"
+ADD deps/ofed-ucx.conf /tmp/
 
-#Uncomment the following lines of code for ADD and RUN
-#to install the uff-converter-tf package
+# Install Mellanox OFED libraries: 5.7+
+ RUN mkdir /opt/dev_mlnx && \
+         wget -O /opt/dev_mlnx/MLNX_OFED_LINUX-5.7-1.0.2.0-ubuntu20.04-x86_64.tgz https://content.mellanox.com/ofed/MLNX_OFED-5.7-1.0.2.0/MLNX_OFED_LINUX-5.7-1.0.2.0-ubuntu20.04-x86_64.tgz --no-check-certificate --no-verbose  && \
+       mv /tmp/ofed-ucx.conf /opt/dev_mlnx/ofed-ucx.conf && \
+       cd  /opt/dev_mlnx && \
+        tar -xf MLNX_OFED_LINUX-5.7-1.0.2.0-ubuntu20.04-x86_64.tgz && \
+        cp /opt/dev_mlnx/ofed-ucx.conf /opt/dev_mlnx/MLNX_OFED_LINUX-5.7-1.0.2.0-ubuntu20.04-x86_64/ && \
+        cd  /opt/dev_mlnx/MLNX_OFED_LINUX-5.7-1.0.2.0-ubuntu20.04-x86_64 && \
+        ls -l /opt/dev_mlnx/MLNX_OFED_LINUX-5.7-1.0.2.0-ubuntu20.04-x86_64  && \
+        chmod +x /opt/dev_mlnx/MLNX_OFED_LINUX-5.7-1.0.2.0-ubuntu20.04-x86_64/mlnxofedinstall && \
+       /opt/dev_mlnx/MLNX_OFED_LINUX-5.7-1.0.2.0-ubuntu20.04-x86_64/mlnxofedinstall --config /opt/dev_mlnx/MLNX_OFED_LINUX-5.7-1.0.2.0-ubuntu20.04-x86_64/ofed-ucx.conf --without-fw-update -q --force && \
+       rm -rf /opt/dev_mlnx
 
-#ADD uff-converter-tf_${TENSORRT_VERSION}_amd64.deb graphsurgeon-tf_${TENSORRT_VERSION}_amd64.deb /root/
-#RUN apt-get update && \
-#	DEBIAN_FRONTEND=noninteractive  apt-get install -y --no-install-recommends \
-#	/root/uff-converter-tf_${TENSORRT_VERSION}_amd64.deb \
-#	/root/graphsurgeon-tf_${TENSORRT_VERSION}_amd64.deb && \
-#	rm /root/uff-converter-tf_${TENSORRT_VERSION}_amd64.deb  \
-#	/root/graphsurgeon-tf_${TENSORRT_VERSION}_amd64.deb
+# Install UCX  1.13.1
+RUN mkdir /opt/dev_ucx2 && \
+        wget -O /opt/dev_ucx2/ucx-1.13.1.tar.gz https://github.com/openucx/ucx/releases/download/v1.13.1/ucx-1.13.1.tar.gz --no-check-certificate --no-verbose  && \
+        cd  /opt/dev_ucx2 && \
+        tar -xf ucx-1.13.1.tar.gz && \
+        cd /opt/dev_ucx2/ucx-1.13.1 && \
+        /opt/dev_ucx2/ucx-1.13.1/contrib/configure-release --prefix=/usr --enable-examples --with-java=no --with-cuda=/usr/local/cuda --enable-mt && \
+        make && make install && \
+        rm -rf /opt/dev_ucx2
 
-# @} Adding uff-converter-tf and graphsurgeon-tf packages
+# install the Triton grpc client library from the prebuilt release package
+RUN mkdir -p  /opt/tritonclient/ && \
+        wget -O /opt/tritonclient/v2.12.0_ubuntu2004.clients.tar.gz https://github.com/triton-inference-server/server/releases/download/v2.12.0/v2.12.0_ubuntu2004.clients.tar.gz --no-check-certificate --no-verbose && \
+        tar xzf /opt/tritonclient/v2.12.0_ubuntu2004.clients.tar.gz -C /opt/tritonclient/ lib include && \
+        rm /opt/tritonclient/v2.12.0_ubuntu2004.clients.tar.gz 
+
+# install protobuf and half
+RUN mkdir -p /opt/proto && \
+    mkdir -p /tmp/temp_proto99 && \
+    mkdir -p /opt/half && \
+    mkdir -p /tmp/half99 && \
+    cd /tmp/temp_proto99 && \
+    wget https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/protoc-3.8.0-linux-x86_64.zip --no-check-certificate --no-verbose  && \
+    /usr/bin/unzip /tmp/temp_proto99/protoc-3.8.0-linux-x86_64.zip -d /opt/proto && \
+    cd /tmp/half99 && \
+    wget https://sourceforge.net/projects/half/files/half/2.1.0/half-2.1.0.zip --no-check-certificate --no-verbose  && \
+    /usr/bin/unzip /tmp/half99/half-2.1.0.zip -d /opt/half && \
+    cd / && \
+    rm -rf /tmp/temp_proto99 && \
+    rm -rf /tmp/half99
+
+# @} Extra Steps
 
 COPY trtserver_base_devel/10_nvidia.json /usr/share/glvnd/egl_vendor.d/10_nvidia.json
 COPY trtserver_base_devel/entrypoint.sh ${DS_DIR}/
@@ -163,17 +224,24 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libnvidia-encode.so.1 /usr/lib/x86_64-linux-
 ADD deps/gRPC_installation.sh /root/
 RUN /root/gRPC_installation.sh
 
+RUN DEBIAN_FRONTEND=noninteractive  apt-get install -y --no-install-recommends libssl-dev
+
 # IP requirement for removal
-RUN rm -f /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudioparsers.so
-RUN rm -f /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfaad.so
-RUN rm -f /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvoaacenc.so
+RUN rm -f /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstaudioparsers.so \
+       /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstx264.so \
+       /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstfaad.so \
+       /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvoaacenc.so 
 RUN rm -f /usr/lib/x86_64-linux-gnu/libavresample* /usr/lib/x86_64-linux-gnu/libavutil* \
-   /usr/lib/x86_64-linux-gnu/libavcodec* /usr/lib/x86_64-linux-gnu/libavformat* \
-   /usr/lib/x86_64-linux-gnu/libavfilter*
+    /usr/lib/x86_64-linux-gnu/libavcodec* /usr/lib/x86_64-linux-gnu/libavformat* \
+    /usr/lib/x86_64-linux-gnu/libavfilter*  /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstde265.so* \
+    /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstx265.so* /usr/lib/x86_64-linux-gnu/libde265.so* /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvpx.so*
+RUN rm -f /usr/lib/x86_64-linux-gnu/libmpeg2.so* /usr/lib/x86_64-linux-gnu/libmpeg2encpp-2.1.so* /usr/lib/x86_64-linux-gnu/libmpg123.so*  \
+    /usr/lib/x86_64-linux-gnu/libx265.so.179 /usr/lib/x86_64-linux-gnu/libx264.so.155 /usr/lib/x86_64-linux-gnu/libvpx.so*  \
+    /usr/lib/x86_64-linux-gnu/libmpeg2convert.so*
 
-# ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libgstbadvideo-1.0.so.0
+#ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libgstbadvideo-1.0.so.0
 
-COPY triton_user_additional_install_devel.sh /opt/user_additional_install_devel.sh
+ADD deps/user_additional_install_devel.sh /opt/
+ADD deps/user_deepstream_python_apps_install.sh /opt/
 
-RUN rm /root/gRPC_installation.sh
-RUN rm -f /root/*.deb
+RUN rm -f /root/gRPC_installation.sh /root/*deb


### PR DESCRIPTION
x86 update only (for Triton 22.09 -> later versions)

Jetson: already latest Triton version (23.01)